### PR TITLE
build: adding build script for all versions

### DIFF
--- a/build-all-versions.sh
+++ b/build-all-versions.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+INITIAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+for TAG in $(git tag --list); do
+    echo ""
+    echo "Building version $TAG"
+    # git switch --detach "$TAG" # for next version of git
+    git checkout "$TAG" --quiet # --quiet to skip the warning about detached HEAD
+    npm run build
+done
+
+echo ""
+echo "Build finished, returning to initial branch"
+# git switch "$TAG" # for next version of git
+git checkout "$INITIAL_BRANCH"


### PR DESCRIPTION
This should be tested after the next release, to unsure that all the versions are correctly built in `dist/`.